### PR TITLE
Avoid importing package during setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,14 +6,14 @@ import os
 from setuptools import setup, find_packages
 
 def read_version():
-    """This reads the version from diffusion_maps/version.py without importing parts of
-    the actual package (which would require some of the dependencies already
+    """This function reads the version from diffusion_maps/version.py without importing
+    parts of the package (which would require some of the dependencies already
     installed)."""
     # code parts were taken from here https://stackoverflow.com/a/67692
 
     path2setup = os.path.dirname(__file__)
-    version_file = os.path.abspath(os.path.join(path2setup, "diffusion_maps",
-                                                "version.py"))
+    version_file = os.path.abspath(
+        os.path.join(path2setup, "diffusion_maps", "version.py"))
 
     spec = importlib.util.spec_from_file_location("version", version_file)
     version = importlib.util.module_from_spec(spec)

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,27 @@
 #!/usr/bin/env python
 
+import importlib
+import os
+
 from setuptools import setup, find_packages
 
-import diffusion_maps
+def read_version():
+    """This reads the version from diffusion_maps/version.py without importing parts of
+    the actual package (which would require some of the dependencies already
+    installed)."""
+    # code parts were taken from here https://stackoverflow.com/a/67692
 
+    path2setup = os.path.dirname(__file__)
+    version_file = os.path.abspath(os.path.join(path2setup, "diffusion_maps",
+                                                "version.py"))
+
+    spec = importlib.util.spec_from_file_location("version", version_file)
+    version = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(version)
+    return version.version.v_short
 
 setup(name='diffusion-maps',
-      version=diffusion_maps.version.v_short,
+      version=read_version(),
       description='Diffusion maps',
       long_description='Library for computing diffusion maps',
       license='MIT License',


### PR DESCRIPTION
Just a minor fix in `setup.py`. If installing the package in a new virtual environment, then the diffusion maps installation `python setup.py install` fails because the dependencies (numpy, etc.) are not yet installed. 